### PR TITLE
Adding hello => hi to the substitution dictionary per lab prompt

### DIFF
--- a/tweet_shortener.rb
+++ b/tweet_shortener.rb
@@ -1,6 +1,7 @@
 # Write your code here.
 def dictionary
 dictionary = {
+  "hello" => "hi",
   "too" => "2",
   "to" => "2",
   "two" =>"2",


### PR DESCRIPTION
This branch adds the key value pair ` hello => hi ` to the dictionary per the prompt:

> "hello" becomes 'hi'
> "to, two, too" become '2' 
> "for, four" become '4'
> 'be' becomes 'b'
> 'you' becomes 'u'
> "at" becomes "@" 
> "and" becomes "&"  